### PR TITLE
Rewrite specs

### DIFF
--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -1,19 +1,17 @@
 require 'rails_helper'
 
 describe City do
-  before do
-    @new_york_city = City.create(name: 'NYC')
-
-    @financial_district = Neighborhood.create(name: 'Fi Di', city: @new_york_city)
-    @green_point = Neighborhood.create(name: 'Green Point', city: @new_york_city)
-    @brighton_beach = Neighborhood.create(name: 'Brighton Beach', city: @new_york_city)
-  end
+  let(:new_york_city) { City.create(name: 'NYC') }
 
   it 'has a name' do
-    expect(@new_york_city.name).to eq('NYC')
+    expect(new_york_city.name).to eq('NYC')
   end
 
   it 'has many neighborhoods' do
-    expect(@new_york_city.neighborhoods).to eq([@financial_district, @green_point, @brighton_beach])
+    financial_district = Neighborhood.create(name: 'Fi Di', city: new_york_city)
+    green_point = Neighborhood.create(name: 'Green Point', city: new_york_city)
+    brighton_beach = Neighborhood.create(name: 'Brighton Beach', city: new_york_city)
+
+    expect(new_york_city.neighborhoods).to eq([financial_district, green_point, brighton_beach])
   end
 end

--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -14,4 +14,24 @@ describe City do
 
     expect(new_york_city.neighborhoods).to eq([financial_district, green_point, brighton_beach])
   end
+
+  context 'listings' do
+    let(:user) { User.create(name: "user") }
+    let(:fidi) { Neighborhood.create(name: 'Fi Di', city: nyc) }
+    let!(:listing) do
+      Listing.create(
+        address: '123 Main Street',
+        listing_type: "private room",
+        title: "Beautiful Apartment on Main Street",
+        description: "My apartment is great. there's a bedroom. close to subway....blah blah",
+        price: 50.00,
+        neighborhood: fidi,
+        host: user
+      )
+    end
+
+    it 'has many listings through neighborhoods' do
+      expect(nyc.listings).to include(listing)
+    end
+  end
 end

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -1,75 +1,79 @@
 require 'rails_helper'
 
 describe Listing do
-  before do
-    @new_york_city = City.create(name: 'NYC')
-
-    @financial_district = Neighborhood.create(name: 'Fi Di', city: @new_york_city)
-
-    @amanda = User.create(name: "Amanda")
-    @logan = User.create(name: "Logan")
-
-    @listing = Listing.create(
-        address: '123 Main Street',
-        listing_type: "private room",
-        title: "Beautiful Apartment on Main Street",
-        description: "My apartment is great. there's a bedroom. close to subway....blah blah",
-        price: 50.00,
-        neighborhood: @financial_district,
-        host: @amanda)
-
-    @reservation = Reservation.create(
-        checkin: '2014-04-25',
-        checkout: '2014-04-30',
-        listing: @listing,
-        guest: @logan)
-
-
-    @review = Review.create(
-        description: "This place was great!",
-        rating: 5,
-        guest: @logan,
-        reservation: @reservation)
+  let(:new_york_city) { City.create(name: 'NYC') }
+  let(:financial_district) { Neighborhood.create(name: 'Fi Di', city: new_york_city) }
+  let(:amanda) { User.create(name: "Amanda") }
+  let(:logan) { User.create(name: "Logan") }
+  let!(:listing) do
+    Listing.create(
+      address: '123 Main Street',
+      listing_type: "private room",
+      title: "Beautiful Apartment on Main Street",
+      description: "My apartment is great. there's a bedroom. close to subway....blah blah",
+      price: 50.00,
+      neighborhood: financial_district,
+      host: amanda
+    )
   end
 
   it 'has a title' do
-    expect(@listing.title).to eq("Beautiful Apartment on Main Street")
+    expect(listing.title).to eq("Beautiful Apartment on Main Street")
   end
 
   it 'has a description' do
-    expect(@listing.description).to eq("My apartment is great. there's a bedroom. close to subway....blah blah")
+    expect(listing.description).to eq("My apartment is great. there's a bedroom. close to subway....blah blah")
   end
 
   it 'has an address' do
-    expect(@listing.address).to eq('123 Main Street')
+    expect(listing.address).to eq('123 Main Street')
   end
 
   it 'has a listing type' do
-    expect(@listing.listing_type).to eq("private room")
+    expect(listing.listing_type).to eq("private room")
   end
 
   it 'has a price' do
-    expect(@listing.price).to eq(50.00)
+    expect(listing.price).to eq(50.00)
   end
 
   it 'belongs to a neighborhood' do
-    expect(@listing.neighborhood.name).to eq("Fi Di")
+    expect(listing.neighborhood.name).to eq("Fi Di")
   end
 
   it 'belongs to a host' do
-    expect(@listing.host.name).to eq("Amanda")
+    expect(listing.host.name).to eq("Amanda")
   end
 
-  it 'has many reservations' do
-    expect(@listing.reservations).to include(@reservation)
-  end
+  context 'reservations (and guests) and reviews' do
+    let!(:reservation) do
+      Reservation.create(
+        checkin: '2014-04-25',
+        checkout: '2014-04-30',
+        listing: listing,
+        guest: logan
+      )
+    end
 
-  it 'knows about all of its guests' do
-    expect(@listing.guests).to include(@logan)
-  end
+    let!(:review) do
+      Review.create(
+        description: "This place was great!",
+        rating: 5,
+        guest: logan,
+        reservation: reservation
+      )
+    end
 
-  it 'has many reviews through reservations' do
-    expect(@listing.reviews).to include(@review)
-  end
+    it 'has many reservations' do
+      expect(listing.reservations).to include(reservation)
+    end
 
+    it 'has many reviews through reservations' do
+      expect(listing.reviews).to include(review)
+    end
+
+    it 'knows about all of its guests' do
+      expect(listing.guests).to include(logan)
+    end
+  end
 end

--- a/spec/models/neighborhood_spec.rb
+++ b/spec/models/neighborhood_spec.rb
@@ -1,33 +1,33 @@
-require 'rails_helper'
+equire 'rails_helper'
 
 describe Neighborhood do
-  before do
-    @new_york_city = City.create(name: 'NYC')
+  let(:nyc) { City.create(name: 'NYC') }
+  let(:brighton_beach) { Neighborhood.create(name: 'Brighton Beach', city: nyc) }
 
-    @brighton_beach = Neighborhood.create(name: 'Brighton Beach', city: @new_york_city)
+  it 'has a name' do
+    expect(brighton_beach.name).to eq('Brighton Beach')
+  end
 
-    @arel = User.create(name: "Arel")
+  it 'belongs to a city' do
+    expect(brighton_beach.city).to be(nyc)
+  end
 
-    @listing = Listing.create(
+  context "listings" do
+    let(:user) { User.create(name: "Arel") }
+    let!(:listing) do
+      Listing.create(
         address: '44 Ridge Lane',
         listing_type: "whole house",
         title: "Beautiful Home on Mountain",
         description: "Whole house for rent on mountain. Many bedrooms.",
         price: 200.00,
-        neighborhood: @brighton_beach,
-        host: @arel)
+        neighborhood: brighton_beach,
+        host: user
+      )
+    end
 
+    it 'has many listings' do
+      expect(brighton_beach.listings).to eq([listing])
+    end
   end
-  it 'has a name' do
-    expect(@brighton_beach.name).to eq('Brighton Beach')
-  end
-
-  it 'belongs to a city' do
-    expect(@brighton_beach.city.name).to eq('NYC')
-  end
-
-  it 'has many listings' do
-    expect(@brighton_beach.listings).to eq([@listing])
-  end
-
 end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1,42 +1,43 @@
 require 'rails_helper'
 
 describe Reservation do
-  before do
-    @new_york_city = City.create(name: 'NYC')
-
-    @financial_district = Neighborhood.create(name: 'Fi Di', city: @new_york_city)
-
-    @amanda = User.create(name: "Amanda")
-
-    @listing = Listing.create(
-        address: '123 Main Street',
-        listing_type: "private room",
-        title: "Beautiful Apartment on Main Street",
-        description: "My apartment is great. there's a bedroom. close to subway....blah blah",
-        price: 50.00,
-        neighborhood: @financial_district,
-        host: @amanda)
-
-    @reservation = Reservation.create(
-        checkin: '2014-04-25',
-        checkout: '2014-04-30',
-        listing: @listing,
-        guest: @logan)
+  let(:nyc) { City.create(name: 'NYC') }
+  let(:fidi) { Neighborhood.create(name: 'Fi Di', city: nyc) }
+  let(:amanda) { User.create(name: "Amanda") }
+  let(:logan) { User.create(name: "Logan") }
+  let(:listing) do
+    Listing.create(
+      address: '123 Main Street',
+      listing_type: "private room",
+      title: "Beautiful Apartment on Main Street",
+      description: "My apartment is great. there's a bedroom. close to subway....blah blah",
+      price: 50.00,
+      neighborhood: fidi,
+      host: amanda
+    )
   end
+  let(:reservation) do
+    Reservation.create(
+      checkin: '2014-04-25',
+      checkout: '2014-04-30',
+      listing: listing,
+      guest: logan
+    )
+  end
+
   it 'has a checkin time' do
-    expect(@reservation.checkin).to eq(Date.parse('2014-04-25'))
+    expect(reservation.checkin).to eq(Date.parse('2014-04-25'))
   end
 
   it 'has a checkout time' do
-    expect(@reservation.checkout).to eq(Date.parse('2014-04-30'))
+    expect(reservation.checkout).to eq(Date.parse('2014-04-30'))
   end
 
   it 'belongs to a guest' do
-    expect(@reservation.guest).to eq(@logan)
+    expect(reservation.guest).to eq(logan)
   end
 
   it 'belongs to a listing' do
-  expect(@reservation.listing).to eq(@listing)
+    expect(reservation.listing).to eq(listing)
   end
-
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,50 +1,51 @@
 require 'rails_helper'
 
 describe Review do
-  before do
-    @new_york_city = City.create(name: 'NYC')
-
-    @financial_district = Neighborhood.create(name: 'Fi Di', city: @new_york_city)
-
-    @logan = User.create(name: "Logan")
-    @amanda = User.create(name: "Amanda")
-
-    @listing = Listing.create(
-        address: '123 Main Street',
-        listing_type: "private room",
-        title: "Beautiful Apartment on Main Street",
-        description: "My apartment is great. There's a bedroom. Close to subway",
-        price: 50.00,
-        neighborhood: @financial_district,
-        host: @amanda)
-
-    @reservation = Reservation.create(
-        checkin: '2014-04-25',
-        checkout: '2014-04-30',
-        listing: @listing,
-        guest: @logan)
-
-    @review = Review.create(
-        description: "This place was great!",
-        rating: 5,
-        guest: @logan,
-        reservation: @reservation)
+  let(:nyc) { City.create(name: 'NYC') }
+  let(:fidi) { Neighborhood.create(name: 'Fi Di', city: nyc) }
+  let(:amanda) { User.create(name: "Amanda") }
+  let(:logan) { User.create(name: "Logan") }
+  let(:listing) do
+    Listing.create(
+      address: '123 Main Street',
+      listing_type: "private room",
+      title: "Beautiful Apartment on Main Street",
+      description: "My apartment is great. there's a bedroom. close to subway....blah blah",
+      price: 50.00,
+      neighborhood: fidi,
+      host: amanda
+    )
+  end
+  let(:reservation) do
+    Reservation.create(
+      checkin: '2014-04-25',
+      checkout: '2014-04-30',
+      listing: listing,
+      guest: logan
+    )
+  end
+  let(:review) do
+    Review.create(
+      description: "This place was great!",
+      rating: 5,
+      guest: logan,
+      reservation: reservation
+    )
   end
 
   it 'has a description' do
-    expect(@review.description).to eq("This place was great!")
+    expect(review.description).to eq("This place was great!")
   end
 
   it 'has a rating' do
-    expect(@review.rating).to eq(5)
+    expect(review.rating).to eq(5)
   end
 
   it 'belongs to a guest' do
-    expect(@review.guest).to eq(@logan)
+    expect(review.guest).to eq(logan)
   end
 
   it 'belongs to a reservation' do
-    expect(@review.reservation).to eq(@reservation)
+    expect(review.reservation).to be(reservation)
   end
-
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,53 +1,64 @@
 require 'rails_helper'
 
 describe User do
-  before do
-    @new_york_city = City.create(name: 'NYC')
-    @green_point = Neighborhood.create(name: 'Green Point', city: @new_york_city)
+  let(:katie) { User.create(name: "Katie") }
 
-    @katie = User.create(name: "Katie")
-    @logan = User.create(name: "Logan")
+  it 'has a name' do
+    expect(katie.name).to eq("Katie")
+  end
 
-    @listing = Listing.create(
+  context "guest and host" do
+    let(:nyc) { City.create(name: 'NYC') }
+    let(:green_point) { Neighborhood.create(name: 'Green Point', city: nyc) }
+    let(:listing) do
+      Listing.create(
         address: '6 Maple Street',
         listing_type: "shared room",
         title: "Shared room in apartment",
         description: "share a room with me because I'm poor",
         price: 15.00,
-        neighborhood: @green_point,
-        host: @katie)
-
-    @reservation = Reservation.create(
+        neighborhood: green_point,
+        host: katie
+      )
+    end
+    let(:logan) { User.create(name: "Logan") }
+    let(:reservation) do
+      Reservation.create(
         checkin: '2014-04-25',
         checkout: '2014-04-30',
-        listing: @listing,
-        guest: @logan)
+        listing: listing,
+        guest: logan
+      )
+    end
 
-    @review = Review.create(
-        description: "Meh, the host I shared a room with snored.",
-        rating: 3,
-        guest: @logan,
-        reservation: @reservation)
+    context "as host" do
+      it "has many listings" do
+        expect(katie.listings).to include(listing)
+      end
+
+      it 'has many reservations through their listing' do
+        expect(katie.reservations).to include(reservation)
+      end
+    end
+
+    context "as guest" do
+      let(:review) do
+        Review.create(
+          description: "Meh, the host I shared a room with snored.",
+          rating: 3,
+          guest: logan,
+          reservation: reservation
+        )
+      end
+
+      it 'has many trips' do
+        expect(logan.trips).to include(reservation)
+      end
+
+
+      it 'has written many reviews' do
+        expect(logan.reviews).to include(review)
+      end
+    end
   end
-
-  it 'has a name' do
-    expect(@katie.name).to eq("Katie")
-  end
-
-  it 'as a host has many listings' do
-    expect(@katie.listings).to include(@listing)
-  end
-
-  it 'as a guest has many trips' do
-    expect(@logan.trips).to include(@reservation)
-  end
-
-  it 'as a host has many reservations through their listing' do
-    expect(@katie.reservations).to include(@reservation)
-  end
-
-  it 'as a guest has written many reviews' do
-    expect(@logan.reviews).to include(@review)
-  end
-
 end


### PR DESCRIPTION
Tests were rewritten so that students could run `rspec`/`learn-test`/`learn` and follow errors in a bit more piecemeal fashion.

Currently, most tests have a ton of setup in a `before` block. This PR tries to break that setup down a little. (Some tests still require a lot of setup, like `revew_spec`.)

@jmburges, could I get some eyes on this? It's preparatory to fixing https://github.com/learn-co-curriculum/flatiron-bnb-methods